### PR TITLE
Don't return 200 with OK as a body

### DIFF
--- a/app/api_controller.rb
+++ b/app/api_controller.rb
@@ -77,9 +77,7 @@ module PodStats
 
         end
 
-        json_message( 200,
-          :ok => "OK"
-        )
+        204
       end
     end
   end

--- a/blueprint.apib
+++ b/blueprint.apib
@@ -19,7 +19,5 @@ HOST: https://stats.cocoapods.org/api
         + cocoapods_version: `0.38.0` (required)
         + pod_try: false (boolean)
 
-+ Response 200 (application/json)
-
-        { "ok": "OK" }
++ Response 204
 

--- a/spec/functional/api/v1/install_spec.rb
+++ b/spec/functional/api/v1/install_spec.rb
@@ -40,10 +40,7 @@ module PodStats
 
       post "/api/v1/install", @data.to_json,  'HTTPS' => 'on'
 
-      last_response.status.should == 200
-      last_response.content_type.should == 'application/json'
-
-      JSON.parse(last_response.body).should == { 'ok' => "OK" }
+      last_response.status.should == 204
     end
 
     it 'creates the right analytics events' do


### PR DESCRIPTION
200 represents a success and sending OKAY in the body is redundant. There should NEVER be an `{"ok": "no"}` response during a successful stats code.