### PR TITLE
Add support for grabbing total stats on a daily basis

### DIFF
--- a/app/models/total_stats.rb
+++ b/app/models/total_stats.rb
@@ -1,0 +1,5 @@
+require_relative '../../lib/pod_metrics'
+
+class TotalStats < Sequel::Model(:total_stats)
+  include PodMetrics
+end

--- a/runner/daily_runner.rb
+++ b/runner/daily_runner.rb
@@ -6,20 +6,21 @@ require_relative '../app/models/pod'
 
 require 'benchmark'
 
-PRODUCT_TYPE_UTI = {
-  :application       => 'com.apple.product-type.application',
-  :framework         => 'com.apple.product-type.framework',
-  :dynamic_library   => 'com.apple.product-type.library.dynamic',
-  :static_library    => 'com.apple.product-type.library.static',
-  :bundle            => 'com.apple.product-type.bundle',
-  :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
-  :app_extension     => 'com.apple.product-type.app-extension',
-  :command_line_tool => 'com.apple.product-type.tool',
-  :watch_app         => 'com.apple.product-type.application.watchapp',
-  :watch_extension   => 'com.apple.product-type.watchkit-extension',
-}.freeze
-
 module PodStats
+
+  PRODUCT_TYPE_UTI = {
+    :application       => 'com.apple.product-type.application',
+    :framework         => 'com.apple.product-type.framework',
+    :dynamic_library   => 'com.apple.product-type.library.dynamic',
+    :static_library    => 'com.apple.product-type.library.static',
+    :bundle            => 'com.apple.product-type.bundle',
+    :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
+    :app_extension     => 'com.apple.product-type.app-extension',
+    :command_line_tool => 'com.apple.product-type.tool',
+    :watch_app         => 'com.apple.product-type.application.watchapp',
+    :watch_extension   => 'com.apple.product-type.watchkit-extension',
+  }.freeze
+
   puts Benchmark.measure {
 
     stats = StatsCoordinator.new

--- a/runner/daily_runner.rb
+++ b/runner/daily_runner.rb
@@ -1,9 +1,23 @@
 require_relative 'stats_coordinator'
+require_relative 'total_stats_coordinator'
 require_relative '../config/init'
 require_relative '../lib/pod_metrics'
 require_relative '../app/models/pod'
 
 require 'benchmark'
+
+PRODUCT_TYPE_UTI = {
+  :application       => 'com.apple.product-type.application',
+  :framework         => 'com.apple.product-type.framework',
+  :dynamic_library   => 'com.apple.product-type.library.dynamic',
+  :static_library    => 'com.apple.product-type.library.static',
+  :bundle            => 'com.apple.product-type.bundle',
+  :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
+  :app_extension     => 'com.apple.product-type.app-extension',
+  :command_line_tool => 'com.apple.product-type.tool',
+  :watch_app         => 'com.apple.product-type.application.watchapp',
+  :watch_extension   => 'com.apple.product-type.watchkit-extension',
+}.freeze
 
 module PodStats
   puts Benchmark.measure {
@@ -16,6 +30,10 @@ module PodStats
       data = stats.stat_for_pod pod.id, pod.name
       stats.update_pod pod.id,data
     end
+
+    total = TotalStatsCoordinator.new
+    total.connection = stats.connection
+    total.update_total_stats_for_today
 
   }.to_s
 end

--- a/runner/stats_coordinator.rb
+++ b/runner/stats_coordinator.rb
@@ -7,19 +7,6 @@ module PodStats
   class StatsCoordinator
     attr_accessor :connection
 
-    PRODUCT_TYPE_UTI = {
-      :application       => 'com.apple.product-type.application',
-      :framework         => 'com.apple.product-type.framework',
-      :dynamic_library   => 'com.apple.product-type.library.dynamic',
-      :static_library    => 'com.apple.product-type.library.static',
-      :bundle            => 'com.apple.product-type.bundle',
-      :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
-      :app_extension     => 'com.apple.product-type.app-extension',
-      :command_line_tool => 'com.apple.product-type.tool',
-      :watch_app         => 'com.apple.product-type.application.watchapp',
-      :watch_extension   => 'com.apple.product-type.watchkit-extension',
-    }.freeze
-
     def connect
       unless @connection
         db = URI(ENV["ANALYTICS_SQL_URL"])

--- a/runner/total_stats_coordinator.rb
+++ b/runner/total_stats_coordinator.rb
@@ -1,0 +1,65 @@
+require_relative '../config/init'
+require_relative '../app/models/total_stats'
+require 'pg'
+
+module PodStats
+
+  class TotalStatsCoordinator
+    attr_accessor :connection
+
+    def get_all_targets type
+      type_id = PRODUCT_TYPE_UTI[type]
+
+      query = <<-eos
+        SELECT COUNT(DISTINCT(user_id))
+        FROM install
+        WHERE product_type = $1
+        AND pod_try = false
+      eos
+      @connection.exec(query, [type_id])[0]["count"].to_i || 0
+    end
+
+    def get_all_podfiles
+      query = <<-eos
+        SELECT COUNT(DISTINCT(user_id))
+        FROM install
+      eos
+      @connection.exec(query)[0]["count"].to_i || 0
+    end
+
+    def get_all_downloads
+      query = <<-eos
+        SELECT COUNT(user_id)
+        FROM install
+      eos
+      @connection.exec(query)[0]["count"].to_i || 0
+    end
+
+    def get_all_extensions
+      query = <<-eos
+        SELECT COUNT(DISTINCT(user_id))
+        FROM install
+        WHERE product_type LIKE '%extension%'
+      eos
+      @connection.exec(query)[0]["count"].to_i || 0
+    end
+
+    def grab_stats
+      {
+        :projects_total => get_all_podfiles,
+        :download_total => get_all_downloads,
+        :app_total => get_all_targets(:application),
+        :tests_total => get_all_targets(:unit_test_bundle),
+        :extensions_total => get_all_extensions,
+        :created_at => Time.new,
+        :updated_at => Time.new
+      }
+    end
+
+    def update_total_stats_for_today
+      stats = grab_stats
+      TotalStats.insert(stats)
+    end
+
+  end
+end

--- a/runner/total_stats_coordinator.rb
+++ b/runner/total_stats_coordinator.rb
@@ -10,37 +10,37 @@ module PodStats
     def get_all_targets type
       type_id = PRODUCT_TYPE_UTI[type]
 
-      query = <<-eos
+      query = <<-SQL
         SELECT COUNT(DISTINCT(user_id))
         FROM install
         WHERE product_type = $1
         AND pod_try = false
-      eos
+      SQL
       @connection.exec(query, [type_id])[0]["count"].to_i || 0
     end
 
     def get_all_podfiles
-      query = <<-eos
+      query = <<-SQL
         SELECT COUNT(DISTINCT(user_id))
         FROM install
-      eos
+      SQL
       @connection.exec(query)[0]["count"].to_i || 0
     end
 
     def get_all_downloads
-      query = <<-eos
+      query = <<-SQL
         SELECT COUNT(user_id)
         FROM install
-      eos
+      SQL
       @connection.exec(query)[0]["count"].to_i || 0
     end
 
     def get_all_extensions
-      query = <<-eos
+      query = <<-SQL
         SELECT COUNT(DISTINCT(user_id))
         FROM install
         WHERE product_type LIKE '%extension%'
-      eos
+      SQL
       @connection.exec(query)[0]["count"].to_i || 0
     end
 
@@ -51,8 +51,8 @@ module PodStats
         :app_total => get_all_targets(:application),
         :tests_total => get_all_targets(:unit_test_bundle),
         :extensions_total => get_all_extensions,
-        :created_at => Time.new,
-        :updated_at => Time.new
+        :created_at => Time.now,
+        :updated_at => Time.now
       }
     end
 


### PR DESCRIPTION
<img width="978" alt="screen shot 2015-09-26 at 07 19 52" src="https://cloud.githubusercontent.com/assets/49038/10116107/feeb3648-641e-11e5-9cb9-d41a38418125.png">

Gives us daily stats on how many pods, apps, frameworks etc etc are coming in.